### PR TITLE
Fix #1

### DIFF
--- a/bfdpie.c
+++ b/bfdpie.c
@@ -813,7 +813,7 @@ static PyObject *pybfd_disassemble_bytes(PyObject *self, PyObject *args)
    int data_len;
    size_t vma;
 
-   if(PyArg_ParseTuple(args, "nis#i", &abfd, &arch_num, &data, &data_len, &vma))
+   if(PyArg_ParseTuple(args, "nis#n", &abfd, &arch_num, &data, &data_len, &vma))
    {
       // Validate the BFD pointer passes.
       if(!abfd)

--- a/tests/bfdpie_test.py
+++ b/tests/bfdpie_test.py
@@ -2,6 +2,12 @@ import unittest
 from bfdpie import *
 
 class Test(unittest.TestCase):
+   def test_large_vma(self):
+      b = Binary()
+
+      b.disassemble(b"\x90", ARCH_I686, 0x80000000)
+      b.disassemble(b"\x90", ARCH_X86_64, 0x80000000)
+
    def test_arch_i686(self):
       # 8048579:   89 e5                   mov    %esp,%ebp
       # 804857b:   53                      push   %ebx


### PR DESCRIPTION
I'm not sure that this fix would work on a machine where `Py_ssize_t` and/or `size_t` are 32 bits. Using `unsigned long long` instead would provide a better guarantee, IMO. But it seems to fix the issue on my 64-bit machine.